### PR TITLE
feat(structure): add initial implementation of Wave SDK wrapper

### DIFF
--- a/CHANGELOG.md.meta
+++ b/CHANGELOG.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: f4dcbba307781c147b07049fa055ba29
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Documentation.meta
+++ b/Documentation.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 06f73aa7a9afca14fba13e1e4fa6f46a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Documentation/API.meta
+++ b/Documentation/API.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: efce7318bb68d3d42838e656c05f74ee
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Documentation/API/Haptics.meta
+++ b/Documentation/API/Haptics.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 438419b7344152a46a6f1ea60a9360a8
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Documentation/API/Haptics/README.md
+++ b/Documentation/API/Haptics/README.md
@@ -1,0 +1,9 @@
+# Namespace Tilia.SDK.WaveXR.Haptics
+
+### Classes
+
+#### [WXRDeviceHapticPulser]
+
+Creates a single haptic pulse on a XR\_Device supported haptic device.
+
+[WXRDeviceHapticPulser]: WXRDeviceHapticPulser.md

--- a/Documentation/API/Haptics/README.md.meta
+++ b/Documentation/API/Haptics/README.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 2f11765854c6de04eac500b24a4f0521
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Documentation/API/Haptics/WXRDeviceHapticPulser.md
+++ b/Documentation/API/Haptics/WXRDeviceHapticPulser.md
@@ -1,0 +1,96 @@
+# Class WXRDeviceHapticPulser
+
+Creates a single haptic pulse on a XR\_Device supported haptic device.
+
+## Contents
+
+* [Inheritance]
+* [Namespace]
+* [Syntax]
+* [Properties]
+  * [Device]
+  * [Duration]
+  * [UseAdaptiveHand]
+* [Methods]
+  * [DoBegin()]
+  * [DoCancel()]
+
+## Details
+
+##### Inheritance
+
+* System.Object
+* WXRDeviceHapticPulser
+
+##### Namespace
+
+* [Tilia.SDK.WaveXR.Haptics]
+
+##### Syntax
+
+```
+public class WXRDeviceHapticPulser : HapticPulser
+```
+
+### Properties
+
+#### Device
+
+The device to pulse.
+
+##### Declaration
+
+```
+public XR_Device Device { get; set; }
+```
+
+#### Duration
+
+The duration to pulse the XR\_Device for in seconds.
+
+##### Declaration
+
+```
+public float Duration { get; set; }
+```
+
+#### UseAdaptiveHand
+
+Determines whether to pulse the adpated dominant controller or just the given [Device].
+
+##### Declaration
+
+```
+public bool UseAdaptiveHand { get; set; }
+```
+
+### Methods
+
+#### DoBegin()
+
+##### Declaration
+
+```
+protected override void DoBegin()
+```
+
+#### DoCancel()
+
+##### Declaration
+
+```
+protected override void DoCancel()
+```
+
+[Tilia.SDK.WaveXR.Haptics]: README.md
+[Device]: WXRDeviceHapticPulser.md#Device
+[Inheritance]: #Inheritance
+[Namespace]: #Namespace
+[Syntax]: #Syntax
+[Properties]: #Properties
+[Device]: #Device
+[Duration]: #Duration
+[UseAdaptiveHand]: #UseAdaptiveHand
+[Methods]: #Methods
+[DoBegin()]: #DoBegin
+[DoCancel()]: #DoCancel

--- a/Documentation/API/Haptics/WXRDeviceHapticPulser.md.meta
+++ b/Documentation/API/Haptics/WXRDeviceHapticPulser.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: b05c13d632a0e1e43aa1adef6c301fd2
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Documentation/API/Tracking.meta
+++ b/Documentation/API/Tracking.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2a96ecfd072c907499acaafd380186ad
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Documentation/API/Tracking/CameraRig.meta
+++ b/Documentation/API/Tracking/CameraRig.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2065b95856efd8c47973e2aeb02d6cf9
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Documentation/API/Tracking/CameraRig/README.md
+++ b/Documentation/API/Tracking/CameraRig/README.md
@@ -1,0 +1,9 @@
+# Namespace Tilia.SDK.WaveXR.Tracking.CameraRig
+
+### Classes
+
+#### [WVRDeviceDetailsRecord]
+
+A DeviceDetailsRecord for a WVR\_DeviceType.
+
+[WVRDeviceDetailsRecord]: WVRDeviceDetailsRecord.md

--- a/Documentation/API/Tracking/CameraRig/README.md.meta
+++ b/Documentation/API/Tracking/CameraRig/README.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 64d6b74a99bdb67418773ebef4a46681
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Documentation/API/Tracking/CameraRig/WVRDeviceDetailsRecord.md
+++ b/Documentation/API/Tracking/CameraRig/WVRDeviceDetailsRecord.md
@@ -1,0 +1,262 @@
+# Class WVRDeviceDetailsRecord
+
+A DeviceDetailsRecord for a WVR\_DeviceType.
+
+## Contents
+
+* [Inheritance]
+* [Namespace]
+* [Syntax]
+* [Properties]
+  * [BatteryChargeStatus]
+  * [BatteryLevel]
+  * [Device]
+  * [HasPassThroughCamera]
+  * [IsConnected]
+  * [PassthroughProcessor]
+  * [Priority]
+  * [TrackingType]
+  * [XRNodeType]
+* [Methods]
+  * [DisablePassThrough()]
+  * [EnablePassThrough()]
+  * [GetBatteryStatusFromChargeStatus(WVR\_DeviceType)]
+  * [GetTrackingType(WVR\_DeviceType)]
+  * [GetXRNodeFromDevice(WVR\_DeviceType)]
+  * [HasPassThroughFeature()]
+  * [SetDeviceType(Int32)]
+
+## Details
+
+##### Inheritance
+
+* System.Object
+* WVRDeviceDetailsRecord
+
+##### Namespace
+
+* [Tilia.SDK.WaveXR.Tracking.CameraRig]
+
+##### Syntax
+
+```
+public class WVRDeviceDetailsRecord : BaseDeviceDetailsRecord
+```
+
+### Properties
+
+#### BatteryChargeStatus
+
+##### Declaration
+
+```
+public override BatteryStatus BatteryChargeStatus { get; protected set; }
+```
+
+#### BatteryLevel
+
+##### Declaration
+
+```
+public override float BatteryLevel { get; protected set; }
+```
+
+#### Device
+
+The device to listen for the state change on.
+
+##### Declaration
+
+```
+public WVR_DeviceType Device { get; set; }
+```
+
+#### HasPassThroughCamera
+
+##### Declaration
+
+```
+public override bool HasPassThroughCamera { get; protected set; }
+```
+
+#### IsConnected
+
+##### Declaration
+
+```
+public override bool IsConnected { get; protected set; }
+```
+
+#### PassthroughProcessor
+
+The [PassthroughLayerProcessor] for handling the camera passthrough.
+
+##### Declaration
+
+```
+public PassthroughLayerProcessor PassthroughProcessor { get; set; }
+```
+
+#### Priority
+
+##### Declaration
+
+```
+public override int Priority { get; protected set; }
+```
+
+#### TrackingType
+
+##### Declaration
+
+```
+public override SpatialTrackingType TrackingType { get; protected set; }
+```
+
+#### XRNodeType
+
+##### Declaration
+
+```
+public override XRNode XRNodeType { get; protected set; }
+```
+
+### Methods
+
+#### DisablePassThrough()
+
+##### Declaration
+
+```
+protected override void DisablePassThrough()
+```
+
+#### EnablePassThrough()
+
+##### Declaration
+
+```
+protected override void EnablePassThrough()
+```
+
+#### GetBatteryStatusFromChargeStatus(WVR\_DeviceType)
+
+Gets the BatteryStatus from the given device.
+
+##### Declaration
+
+```
+protected virtual BatteryStatus GetBatteryStatusFromChargeStatus(WVR_DeviceType device)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| WVR\_DeviceType | device | The device to get battery status for. |
+
+##### Returns
+
+| Type | Description |
+| --- | --- |
+| BatteryStatus | The current device battery status. |
+
+#### GetTrackingType(WVR\_DeviceType)
+
+Gets the SpatialTrackingType of the given device.
+
+##### Declaration
+
+```
+protected virtual SpatialTrackingType GetTrackingType(WVR_DeviceType device)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| WVR\_DeviceType | device | The device to check tracking on. |
+
+##### Returns
+
+| Type | Description |
+| --- | --- |
+| SpatialTrackingType | Thge found tracking type. |
+
+#### GetXRNodeFromDevice(WVR\_DeviceType)
+
+Gets the corresponding XRNode from the given WVR\_DeviceType.
+
+##### Declaration
+
+```
+protected virtual XRNode GetXRNodeFromDevice(WVR_DeviceType device)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| WVR\_DeviceType | device | The device type to convert. |
+
+##### Returns
+
+| Type | Description |
+| --- | --- |
+| XRNode | The converted XR Node. |
+
+#### HasPassThroughFeature()
+
+Determines whether the device has a passthrough camera feature.
+
+##### Declaration
+
+```
+protected virtual bool HasPassThroughFeature()
+```
+
+##### Returns
+
+| Type | Description |
+| --- | --- |
+| System.Boolean | Whether there is a passthrough camera feature. |
+
+#### SetDeviceType(Int32)
+
+Sets the DeviceType.
+
+##### Declaration
+
+```
+public virtual void SetDeviceType(int index)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| System.Int32 | index | The index of the WVR\_DeviceType. |
+
+[Tilia.SDK.WaveXR.Tracking.CameraRig]: README.md
+[PassthroughLayerProcessor]: ../../Visual/PassthroughLayerProcessor.md
+[Inheritance]: #Inheritance
+[Namespace]: #Namespace
+[Syntax]: #Syntax
+[Properties]: #Properties
+[BatteryChargeStatus]: #BatteryChargeStatus
+[BatteryLevel]: #BatteryLevel
+[Device]: #Device
+[HasPassThroughCamera]: #HasPassThroughCamera
+[IsConnected]: #IsConnected
+[PassthroughProcessor]: #PassthroughProcessor
+[Priority]: #Priority
+[TrackingType]: #TrackingType
+[XRNodeType]: #XRNodeType
+[Methods]: #Methods
+[DisablePassThrough()]: #DisablePassThrough
+[EnablePassThrough()]: #EnablePassThrough
+[GetBatteryStatusFromChargeStatus(WVR\_DeviceType)]: #GetBatteryStatusFromChargeStatusWVR\_DeviceType
+[GetTrackingType(WVR\_DeviceType)]: #GetTrackingTypeWVR\_DeviceType
+[GetXRNodeFromDevice(WVR\_DeviceType)]: #GetXRNodeFromDeviceWVR\_DeviceType
+[HasPassThroughFeature()]: #HasPassThroughFeature
+[SetDeviceType(Int32)]: #SetDeviceTypeInt32

--- a/Documentation/API/Tracking/CameraRig/WVRDeviceDetailsRecord.md.meta
+++ b/Documentation/API/Tracking/CameraRig/WVRDeviceDetailsRecord.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: b7090c95f71f50141b1cde5013afa570
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Documentation/API/Visual.meta
+++ b/Documentation/API/Visual.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 647fa4e7bd2ea1c468f83b991fff480b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Documentation/API/Visual/OverlayPassthroughLayerProcessor.md
+++ b/Documentation/API/Visual/OverlayPassthroughLayerProcessor.md
@@ -1,0 +1,146 @@
+# Class OverlayPassthroughLayerProcessor
+
+Implements the WaveXR Overlay camera passthrough layer.
+
+## Contents
+
+* [Inheritance]
+* [Namespace]
+* [Syntax]
+* [Properties]
+  * [AlphaValue]
+* [Methods]
+  * [DisablePassthrough()]
+  * [EnablePassthrough()]
+  * [OnAfterAlphaValueChange()]
+  * [OnEnable()]
+  * [TogglePassthrough(Boolean)]
+
+## Details
+
+##### Inheritance
+
+* System.Object
+* [PassthroughLayerProcessor]
+* OverlayPassthroughLayerProcessor
+
+##### Inherited Members
+
+[PassthroughLayerProcessor.ImageQuality]
+
+[PassthroughLayerProcessor.OnAfterImageQualityChange()]
+
+##### Namespace
+
+* [Tilia.SDK.WaveXR.Visual]
+
+##### Syntax
+
+```
+public class OverlayPassthroughLayerProcessor : PassthroughLayerProcessor
+```
+
+### Properties
+
+#### AlphaValue
+
+The alpha level of the overlay passthrough layer.
+
+##### Declaration
+
+```
+public float AlphaValue { get; set; }
+```
+
+### Methods
+
+#### DisablePassthrough()
+
+Disables the camera passthrough.
+
+##### Declaration
+
+```
+public override void DisablePassthrough()
+```
+
+##### Overrides
+
+[PassthroughLayerProcessor.DisablePassthrough()]
+
+#### EnablePassthrough()
+
+Enables the camera passthrough.
+
+##### Declaration
+
+```
+public override void EnablePassthrough()
+```
+
+##### Overrides
+
+[PassthroughLayerProcessor.EnablePassthrough()]
+
+#### OnAfterAlphaValueChange()
+
+Called after [AlphaValue] has been changed.
+
+##### Declaration
+
+```
+protected virtual void OnAfterAlphaValueChange()
+```
+
+#### OnEnable()
+
+##### Declaration
+
+```
+protected override void OnEnable()
+```
+
+##### Overrides
+
+[PassthroughLayerProcessor.OnEnable()]
+
+#### TogglePassthrough(Boolean)
+
+Toggles the camera passthrough state.
+
+##### Declaration
+
+```
+public override void TogglePassthrough(bool enabled)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| System.Boolean | enabled | Whether to toggle to the enabled state or not. |
+
+##### Overrides
+
+[PassthroughLayerProcessor.TogglePassthrough(Boolean)]
+
+[PassthroughLayerProcessor]: PassthroughLayerProcessor.md
+[PassthroughLayerProcessor.ImageQuality]: PassthroughLayerProcessor.md#Tilia_SDK_WaveXR_Visual_PassthroughLayerProcessor_ImageQuality
+[PassthroughLayerProcessor.OnAfterImageQualityChange()]: PassthroughLayerProcessor.md#Tilia_SDK_WaveXR_Visual_PassthroughLayerProcessor_OnAfterImageQualityChange
+[Tilia.SDK.WaveXR.Visual]: README.md
+[PassthroughLayerProcessor.DisablePassthrough()]: PassthroughLayerProcessor.md#Tilia_SDK_WaveXR_Visual_PassthroughLayerProcessor_DisablePassthrough
+[PassthroughLayerProcessor.EnablePassthrough()]: PassthroughLayerProcessor.md#Tilia_SDK_WaveXR_Visual_PassthroughLayerProcessor_EnablePassthrough
+[AlphaValue]: OverlayPassthroughLayerProcessor.md#AlphaValue
+[PassthroughLayerProcessor.OnEnable()]: PassthroughLayerProcessor.md#Tilia_SDK_WaveXR_Visual_PassthroughLayerProcessor_OnEnable
+[PassthroughLayerProcessor.TogglePassthrough(Boolean)]: PassthroughLayerProcessor.md#Tilia_SDK_WaveXR_Visual_PassthroughLayerProcessor_TogglePassthrough_System_Boolean_
+[Inheritance]: #Inheritance
+[Namespace]: #Namespace
+[Syntax]: #Syntax
+[Properties]: #Properties
+[AlphaValue]: #AlphaValue
+[Methods]: #Methods
+[DisablePassthrough()]: #DisablePassthrough
+[EnablePassthrough()]: #EnablePassthrough
+[OnAfterAlphaValueChange()]: #OnAfterAlphaValueChange
+[OnEnable()]: #OnEnable
+[TogglePassthrough(Boolean)]: #TogglePassthroughBoolean

--- a/Documentation/API/Visual/OverlayPassthroughLayerProcessor.md.meta
+++ b/Documentation/API/Visual/OverlayPassthroughLayerProcessor.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: febfa92b2386fa145b433c95283e124c
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Documentation/API/Visual/PassthroughLayerProcessor.md
+++ b/Documentation/API/Visual/PassthroughLayerProcessor.md
@@ -1,0 +1,120 @@
+# Class PassthroughLayerProcessor
+
+The basis for defining a WaveXR passthrough layer.
+
+## Contents
+
+* [Inheritance]
+* [Namespace]
+* [Syntax]
+* [Properties]
+  * [ImageQuality]
+* [Methods]
+  * [DisablePassthrough()]
+  * [EnablePassthrough()]
+  * [OnAfterImageQualityChange()]
+  * [OnEnable()]
+  * [TogglePassthrough(Boolean)]
+
+## Details
+
+##### Inheritance
+
+* System.Object
+* PassthroughLayerProcessor
+* [OverlayPassthroughLayerProcessor]
+* [UnderlayPassthroughLayerProcessor]
+
+##### Namespace
+
+* [Tilia.SDK.WaveXR.Visual]
+
+##### Syntax
+
+```
+public abstract class PassthroughLayerProcessor : MonoBehaviour
+```
+
+### Properties
+
+#### ImageQuality
+
+The image quality of the passthrough layer.
+
+##### Declaration
+
+```
+public WVR_PassthroughImageQuality ImageQuality { get; set; }
+```
+
+### Methods
+
+#### DisablePassthrough()
+
+Disables the camera passthrough.
+
+##### Declaration
+
+```
+public abstract void DisablePassthrough()
+```
+
+#### EnablePassthrough()
+
+Enables the camera passthrough.
+
+##### Declaration
+
+```
+public abstract void EnablePassthrough()
+```
+
+#### OnAfterImageQualityChange()
+
+Called after [ImageQuality] has been changed.
+
+##### Declaration
+
+```
+protected virtual void OnAfterImageQualityChange()
+```
+
+#### OnEnable()
+
+##### Declaration
+
+```
+protected virtual void OnEnable()
+```
+
+#### TogglePassthrough(Boolean)
+
+Toggles the camera passthrough state.
+
+##### Declaration
+
+```
+public abstract void TogglePassthrough(bool enabled)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| System.Boolean | enabled | Whether to toggle to the enabled state or not. |
+
+[OverlayPassthroughLayerProcessor]: OverlayPassthroughLayerProcessor.md
+[UnderlayPassthroughLayerProcessor]: UnderlayPassthroughLayerProcessor.md
+[Tilia.SDK.WaveXR.Visual]: README.md
+[ImageQuality]: PassthroughLayerProcessor.md#ImageQuality
+[Inheritance]: #Inheritance
+[Namespace]: #Namespace
+[Syntax]: #Syntax
+[Properties]: #Properties
+[ImageQuality]: #ImageQuality
+[Methods]: #Methods
+[DisablePassthrough()]: #DisablePassthrough
+[EnablePassthrough()]: #EnablePassthrough
+[OnAfterImageQualityChange()]: #OnAfterImageQualityChange
+[OnEnable()]: #OnEnable
+[TogglePassthrough(Boolean)]: #TogglePassthroughBoolean

--- a/Documentation/API/Visual/PassthroughLayerProcessor.md.meta
+++ b/Documentation/API/Visual/PassthroughLayerProcessor.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 72519ec202192014ea9a95d5ad12ba60
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Documentation/API/Visual/README.md
+++ b/Documentation/API/Visual/README.md
@@ -1,0 +1,19 @@
+# Namespace Tilia.SDK.WaveXR.Visual
+
+### Classes
+
+#### [OverlayPassthroughLayerProcessor]
+
+Implements the WaveXR Overlay camera passthrough layer.
+
+#### [PassthroughLayerProcessor]
+
+The basis for defining a WaveXR passthrough layer.
+
+#### [UnderlayPassthroughLayerProcessor]
+
+Implements the WaveXR Underlay camera passthrough layer.
+
+[OverlayPassthroughLayerProcessor]: OverlayPassthroughLayerProcessor.md
+[PassthroughLayerProcessor]: PassthroughLayerProcessor.md
+[UnderlayPassthroughLayerProcessor]: UnderlayPassthroughLayerProcessor.md

--- a/Documentation/API/Visual/README.md.meta
+++ b/Documentation/API/Visual/README.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 7d4129057ef2141439ec35ed78ed935a
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Documentation/API/Visual/UnderlayPassthroughLayerProcessor.md
+++ b/Documentation/API/Visual/UnderlayPassthroughLayerProcessor.md
@@ -1,0 +1,105 @@
+# Class UnderlayPassthroughLayerProcessor
+
+Implements the WaveXR Underlay camera passthrough layer.
+
+## Contents
+
+* [Inheritance]
+* [Namespace]
+* [Syntax]
+* [Methods]
+  * [DisablePassthrough()]
+  * [EnablePassthrough()]
+  * [TogglePassthrough(Boolean)]
+
+## Details
+
+##### Inheritance
+
+* System.Object
+* [PassthroughLayerProcessor]
+* UnderlayPassthroughLayerProcessor
+
+##### Inherited Members
+
+[PassthroughLayerProcessor.ImageQuality]
+
+[PassthroughLayerProcessor.OnEnable()]
+
+[PassthroughLayerProcessor.OnAfterImageQualityChange()]
+
+##### Namespace
+
+* [Tilia.SDK.WaveXR.Visual]
+
+##### Syntax
+
+```
+public class UnderlayPassthroughLayerProcessor : PassthroughLayerProcessor
+```
+
+### Methods
+
+#### DisablePassthrough()
+
+Disables the camera passthrough.
+
+##### Declaration
+
+```
+public override void DisablePassthrough()
+```
+
+##### Overrides
+
+[PassthroughLayerProcessor.DisablePassthrough()]
+
+#### EnablePassthrough()
+
+Enables the camera passthrough.
+
+##### Declaration
+
+```
+public override void EnablePassthrough()
+```
+
+##### Overrides
+
+[PassthroughLayerProcessor.EnablePassthrough()]
+
+#### TogglePassthrough(Boolean)
+
+Toggles the camera passthrough state.
+
+##### Declaration
+
+```
+public override void TogglePassthrough(bool enabled)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| System.Boolean | enabled | Whether to toggle to the enabled state or not. |
+
+##### Overrides
+
+[PassthroughLayerProcessor.TogglePassthrough(Boolean)]
+
+[PassthroughLayerProcessor]: PassthroughLayerProcessor.md
+[PassthroughLayerProcessor.ImageQuality]: PassthroughLayerProcessor.md#Tilia_SDK_WaveXR_Visual_PassthroughLayerProcessor_ImageQuality
+[PassthroughLayerProcessor.OnEnable()]: PassthroughLayerProcessor.md#Tilia_SDK_WaveXR_Visual_PassthroughLayerProcessor_OnEnable
+[PassthroughLayerProcessor.OnAfterImageQualityChange()]: PassthroughLayerProcessor.md#Tilia_SDK_WaveXR_Visual_PassthroughLayerProcessor_OnAfterImageQualityChange
+[Tilia.SDK.WaveXR.Visual]: README.md
+[PassthroughLayerProcessor.DisablePassthrough()]: PassthroughLayerProcessor.md#Tilia_SDK_WaveXR_Visual_PassthroughLayerProcessor_DisablePassthrough
+[PassthroughLayerProcessor.EnablePassthrough()]: PassthroughLayerProcessor.md#Tilia_SDK_WaveXR_Visual_PassthroughLayerProcessor_EnablePassthrough
+[PassthroughLayerProcessor.TogglePassthrough(Boolean)]: PassthroughLayerProcessor.md#Tilia_SDK_WaveXR_Visual_PassthroughLayerProcessor_TogglePassthrough_System_Boolean_
+[Inheritance]: #Inheritance
+[Namespace]: #Namespace
+[Syntax]: #Syntax
+[Methods]: #Methods
+[DisablePassthrough()]: #DisablePassthrough
+[EnablePassthrough()]: #EnablePassthrough
+[TogglePassthrough(Boolean)]: #TogglePassthroughBoolean

--- a/Documentation/API/Visual/UnderlayPassthroughLayerProcessor.md.meta
+++ b/Documentation/API/Visual/UnderlayPassthroughLayerProcessor.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: ee59ecedef4f1934aa3623cfed1a68d6
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Documentation/HowToGuides.meta
+++ b/Documentation/HowToGuides.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ffa02bdc923b00549b92ad475cc12294
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Documentation/HowToGuides/Installation.meta
+++ b/Documentation/HowToGuides/Installation.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f35ec8214082fcb4ba7c1c9a2a5da243
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Documentation/HowToGuides/Installation/README.md
+++ b/Documentation/HowToGuides/Installation/README.md
@@ -2,18 +2,85 @@
 
 > * Level: Beginner
 >
-> * Reading Time: {x} minutes
+> * Reading Time: 5 minutes
 >
-> * Checked with: {platform and version}
+> * Checked with:
+>   * Unity 2019.4.40f1
+>   * Vive Wave XR Plugin 5.2.0-r.8
+>   * Vive Wave XR Plugin - Essence 5.2.0-r.8
+>   * Vive Wave XR Plugin - Native 5.2.0-r.8
 
 ## Introduction
 
-{Description of how the package is digested into the supported platform.}
+The [WaveXR Plugin] asset for the [Unity] software provides direct access to the WaveXR hardware API and therefore offers a number of additional features outside of the default Unity software XR offering.
+
+This package contains the following functionality:
+
+* CameraRig wrapper so a WaveXR specific CameraRig prefab can be used with the [Tilia.CameraRigs.TrackedAlias.Unity].
+* Controller haptic feedback utilizing `WXRDevice`.
 
 ## Let's Start
 
-### Step X
+### Step 1
 
-{Describe each step with any useful imagery.}
+> You may skip this step if you already have a Unity project to import the package into.
+
+* Create a new project in the Unity software version `2019.4.40f1` (or above) using `3D Template` or open an existing project.
+
+### Step 2: Configuring the Unity project
+
+* Ensure the project `Scripting Runtime Version` is set to `.NET 4.x Equivalent`:
+  * In the Unity software select `Main Menu -> Edit -> Project Settings` to open the `Project Settings` inspector.
+  * Select `Player` from the left hand menu in the `Project Settings` window.
+  * In the `Player` settings panel expand `Other Settings`.
+  * Ensure the `Scripting Runtime Version` is set to `.NET 4.x Equivalent`.
+
+### Step 3: Adding the Vive WaveXR Plugin asset to the Unity project.
+
+* Visit the HTC Vive website and follow the [SDK Installation Instructions] and update the Unity project Scoped Registries to include the HTC Vive registry.
+
+> The Tilia.SDK.WaveXR.Unity package will automatically include the required WaveXR Plugin packages so they do not need manually installing.
+
+### Step 4: Adding the package to the Unity project manifest
+
+* Navigate to the `Packages` directory of your project.
+* Adjust the [project manifest file][Project-Manifest] `manifest.json` in a text editor.
+  * Ensure `https://registry.npmjs.org/` is part of `scopedRegistries`.
+    * Ensure `io.extendreality` is part of `scopes`.
+  * Add `io.extendreality.tilia.sdk.wavexr.unity` to `dependencies`, stating the latest version.
+
+  A minimal example ends up looking like this. Please note that the version `X.Y.Z` stated here is to be replaced with [the latest released version][Latest-Release] which is currently [![Release][Version-Release]][Releases].
+  ```json
+  {
+    "scopedRegistries": [
+      {
+        "name": "npmjs",
+        "url": "https://registry.npmjs.org/",
+        "scopes": [
+          "io.extendreality"
+        ]
+      }
+    ],
+    "dependencies": {
+      "io.extendreality.tilia.sdk.wavexr.unity": "X.Y.Z",
+      ...
+    }
+  }
+  ```
+* Switch back to the Unity software and wait for it to finish importing the added package.
 
 ### Done
+
+The WaveXR Plugin package will now be available in your Unity project `Packages` directory ready for use in your project.
+
+The package will now also show up in the Unity Package Manager UI. From then on the package can be updated by selecting the package in the Unity Package Manager and clicking on the `Update` button or using the version selection UI.
+
+[WaveXR Plugin]: https://developer.vive.com/resources/vive-wave/tutorials/installing-wave-xr-plugin-unity/
+[SDK Installation Instructions]: https://hub.vive.com/storage/docs/en-us/UnityXR/UnityXRGettingStart.html#adding-the-vive-registry
+[Unity]: https://unity3d.com/
+[Tilia.CameraRigs.TrackedAlias.Unity]: https://github.com/ExtendRealityLtd/Tilia.CameraRigs.TrackedAlias.Unity
+[Unity Package Manager]: https://docs.unity3d.com/Manual/upm-ui.html
+[Project-Manifest]: https://docs.unity3d.com/Manual/upm-manifestPrj.html
+[Version-Release]: https://img.shields.io/github/release/ExtendRealityLtd/Tilia.SDK.WaveXR.Unity.svg
+[Releases]: ../../../../../releases
+[Latest-Release]: ../../../../../releases/latest

--- a/Documentation/HowToGuides/Installation/README.md.meta
+++ b/Documentation/HowToGuides/Installation/README.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 80278d28718560144a10297b0bf4436f
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor.meta
+++ b/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f0085fd6d4916be4fa2f8378e86a2a1e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Tilia.SDK.WaveXR.Unity.Editor.asmdef
+++ b/Editor/Tilia.SDK.WaveXR.Unity.Editor.asmdef
@@ -1,0 +1,17 @@
+{
+    "name": "Tilia.SDK.WaveXR.Unity.Editor",
+    "references": [
+        "Zinnia.Editor"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Editor/Tilia.SDK.WaveXR.Unity.Editor.asmdef.meta
+++ b/Editor/Tilia.SDK.WaveXR.Unity.Editor.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 4b0f864b203a978488ae41dc4bb1281b
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Utility.meta
+++ b/Editor/Utility.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b2716d19a77fd5048a61689c1b7fdbde
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Utility/PrefabCreator.cs
+++ b/Editor/Utility/PrefabCreator.cs
@@ -1,0 +1,27 @@
+﻿namespace Tilia.SDK.WaveXR.Utility
+{
+    using System.IO;
+    using UnityEditor;
+    using Zinnia.Utility;
+
+    public class PrefabCreator : BasePrefabCreator
+    {
+        private const string group = "Tilia/";
+        private const string menuItemRoot = topLevelMenuLocation + group + subLevelMenuLocation;
+
+        private const string package = "io.extendreality.tilia.sdk.wavexr.unity";
+        private const string baseDirectory = "Runtime";
+        private const string prefabDirectory = "Prefabs";
+        private const string prefabSuffix = ".prefab";
+
+        private const string prefabCameraRigsWaveXRIntegration = "CameraRigs.WaveXR";
+
+        [MenuItem(menuItemRoot + "CameraRigs/" + prefabCameraRigsWaveXRIntegration, false, priority)]
+        private static void AddCameraRigsWaveXRIntegration()
+        {
+            string prefab = prefabCameraRigsWaveXRIntegration + prefabSuffix;
+            string packageLocation = Path.Combine(packageRoot, package, baseDirectory, prefabDirectory, prefab);
+            CreatePrefab(packageLocation);
+        }
+    }
+}

--- a/Editor/Utility/PrefabCreator.cs.meta
+++ b/Editor/Utility/PrefabCreator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c4ec1ffd0d03c8a47a345eb800468084
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/LICENSE.md.meta
+++ b/LICENSE.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 0c8a9f8f61475884d91e79a170c2a4ee
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Tilia logo][Tilia-Image]](#)
 
-> ### Tilia {scope} {feature} {platform?}
-> {Description of feature}.
+> ### SDK -> WaveXR Plugin for the Unity Software
+> SDK Wrappers for the WaveXR Plugin Unity asset.
 
 [![Release][Version-Release]][Releases]
 [![License][License-Badge]][License]
@@ -9,9 +9,15 @@
 
 ## Introduction
 
-{Introduction into the purpose of the feature.}
+The [WaveXR Plugin] asset for the [Unity] software provides direct access to the WaveXR hardware API and therefore offers a number of additional features outside of the default Unity software XR offering.
 
-> **Requires** {platform and minimum version number}.
+This SDK Wrapper enables the WaveXR Plugin features to be used with other Tilia packages for tighter integration.
+
+> **Requires**:
+> * The Unity software version `2019.4.40f1` (or above).
+> * The Vive Wave XR Plugin asset `5.2.0-r.8` (or above).
+> * The Vive Wave XR Plugin - Essence asset `5.2.0-r.8` (or above).
+> * The Vive Wave XR Plugin - Native asset `5.2.0-r.8` (or above).
 
 ## Getting Started
 
@@ -35,9 +41,9 @@ Please refer to the Extend Reality [Code of Conduct].
 
 Code released under the [MIT License][License].
 
-[License-Badge]: https://img.shields.io/github/license/ExtendRealityLtd/Tilia.{scope}.{feature}.{platform?}.svg
-[Version-Release]: https://img.shields.io/github/release/ExtendRealityLtd/Tilia.{scope}.{feature}.{platform?}.svg
-[project coding conventions]: https://github.com/ExtendRealityLtd/.github/blob/master/CONVENTIONS/{project_type}
+[License-Badge]: https://img.shields.io/github/license/ExtendRealityLtd/Tilia.SDK.WaveXR.Unity.svg
+[Version-Release]: https://img.shields.io/github/release/ExtendRealityLtd/Tilia.SDK.WaveXR.Unity.svg
+[project coding conventions]: https://github.com/ExtendRealityLtd/.github/blob/master/CONVENTIONS/UNITY3D.md
 
 [Tilia-Image]: https://raw.githubusercontent.com/ExtendRealityLtd/related-media/main/github/readme/tilia.png
 [License]: LICENSE.md
@@ -49,3 +55,6 @@ Code released under the [MIT License][License].
 [Releases]: ../../releases
 [Contributing guidelines]: https://github.com/ExtendRealityLtd/.github/blob/master/CONTRIBUTING.md
 [Code of Conduct]: https://github.com/ExtendRealityLtd/.github/blob/master/CODE_OF_CONDUCT.md
+
+[WaveXR Plugin]: https://developer.vive.com/resources/vive-wave/tutorials/installing-wave-xr-plugin-unity/
+[Unity]: https://unity3d.com/

--- a/README.md.meta
+++ b/README.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 290a6db2995a5974b95ce0e8d386f8a8
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime.meta
+++ b/Runtime.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b473721707c763343a2f38f6a0ee32ec
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Prefabs.meta
+++ b/Runtime/Prefabs.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f4635a19f28655a44a5588dc7b912ddf
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Prefabs/CameraRigs.WaveXR.prefab
+++ b/Runtime/Prefabs/CameraRigs.WaveXR.prefab
@@ -1,0 +1,1893 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &7942253547472280050
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7942253547472280051}
+  - component: {fileID: 7942253547472280052}
+  m_Layer: 0
+  m_Name: ShortLight
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7942253547472280051
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7942253547472280050}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 7942253548006442778}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &7942253547472280052
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7942253547472280050}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6fec9b03b1c34f846a9871a0e725ef7a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  intensity: 0.15
+  device: 2
+  duration: 0.1
+  useAdaptiveHand: 0
+--- !u!1 &7942253547549808209
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7942253547549808210}
+  - component: {fileID: 7942253547549808211}
+  m_Layer: 0
+  m_Name: ShortLight
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7942253547549808210
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7942253547549808209}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 7942253548697926261}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &7942253547549808211
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7942253547549808209}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6fec9b03b1c34f846a9871a0e725ef7a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  intensity: 0.15
+  device: 3
+  duration: 0.1
+  useAdaptiveHand: 0
+--- !u!1 &7942253547552027027
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7942253547552027028}
+  - component: {fileID: 7942253547552027029}
+  m_Layer: 0
+  m_Name: LongMedium
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7942253547552027028
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7942253547552027027}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 7942253548697926261}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &7942253547552027029
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7942253547552027027}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6fec9b03b1c34f846a9871a0e725ef7a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  intensity: 0.35
+  device: 3
+  duration: 0.5
+  useAdaptiveHand: 0
+--- !u!1 &7942253547616981655
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7942253547616981656}
+  - component: {fileID: 7942253547616981657}
+  m_Layer: 0
+  m_Name: ContinuousStrong
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7942253547616981656
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7942253547616981655}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 7942253548697926261}
+  m_RootOrder: 8
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &7942253547616981657
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7942253547616981655}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6fec9b03b1c34f846a9871a0e725ef7a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  intensity: 1
+  device: 3
+  duration: Infinity
+  useAdaptiveHand: 0
+--- !u!1 &7942253547704166939
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7942253547704166941}
+  - component: {fileID: 7942253547704166940}
+  m_Layer: 0
+  m_Name: ContinuousStrong
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7942253547704166941
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7942253547704166939}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 7942253548006442778}
+  m_RootOrder: 8
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &7942253547704166940
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7942253547704166939}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6fec9b03b1c34f846a9871a0e725ef7a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  intensity: 1
+  device: 2
+  duration: Infinity
+  useAdaptiveHand: 0
+--- !u!1 &7942253547804923114
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7942253547804923115}
+  - component: {fileID: 7942253547804923116}
+  m_Layer: 0
+  m_Name: LongLight
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7942253547804923115
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7942253547804923114}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 7942253548697926261}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &7942253547804923116
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7942253547804923114}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6fec9b03b1c34f846a9871a0e725ef7a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  intensity: 0.15
+  device: 3
+  duration: 0.5
+  useAdaptiveHand: 0
+--- !u!1 &7942253547876487858
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7942253547876487862}
+  - component: {fileID: 7942253547876487861}
+  - component: {fileID: 7942253547876487859}
+  - component: {fileID: 7942253547876487860}
+  m_Layer: 0
+  m_Name: Right Controller
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7942253547876487862
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7942253547876487858}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 691168427085168206}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &7942253547876487861
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7942253547876487858}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5a2a9c34df4095f47b9ca8f975175f5b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Device: 1
+  m_PoseSource: 5
+  m_PoseProviderComponent: {fileID: 0}
+  m_TrackingType: 0
+  m_UpdateType: 0
+  m_UseRelativeTransform: 0
+--- !u!114 &7942253547876487859
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7942253547876487858}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6ef6888ffd7db64479799fc534e1d0d1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  TrackingBegun:
+    m_PersistentCalls:
+      m_Calls: []
+  ConnectionStatusChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  TrackingTypeChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  BatteryChargeStatusChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  PassThroughCameraWasEnabled:
+    m_PersistentCalls:
+      m_Calls: []
+  PassThroughCameraWasDisabled:
+    m_PersistentCalls:
+      m_Calls: []
+  device: 2
+  passthroughProcessor: {fileID: 0}
+--- !u!114 &7942253547876487860
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7942253547876487858}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a11862926720f544fb5d904995c2b57b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  source:
+    field: {fileID: 7942253547876487859}
+  onlyProcessOnActiveAndEnabled: 1
+  interval: 0.25
+--- !u!1 &7942253548006442776
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7942253548006442778}
+  - component: {fileID: 7942253548006442777}
+  m_Layer: 0
+  m_Name: RightHapticProfiles
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7942253548006442778
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7942253548006442776}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 7942253547472280051}
+  - {fileID: 7942253549173382209}
+  - {fileID: 7942253548521844097}
+  - {fileID: 7942253549292885115}
+  - {fileID: 7942253548155841925}
+  - {fileID: 7942253548912263672}
+  - {fileID: 7942253549258600815}
+  - {fileID: 7942253549076793250}
+  - {fileID: 7942253547704166941}
+  m_Father: {fileID: 7942253548554999218}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &7942253548006442777
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7942253548006442776}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0dea9bd4fa4b5cc4b9b36a77382cb3b5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Obtained:
+    m_PersistentCalls:
+      m_Calls: []
+  Found:
+    m_PersistentCalls:
+      m_Calls: []
+  NotFound:
+    m_PersistentCalls:
+      m_Calls: []
+  IsEmpty:
+    m_PersistentCalls:
+      m_Calls: []
+  IsPopulated:
+    m_PersistentCalls:
+      m_Calls: []
+  Populated:
+    m_PersistentCalls:
+      m_Calls: []
+  Added:
+    m_PersistentCalls:
+      m_Calls: []
+  Removed:
+    m_PersistentCalls:
+      m_Calls: []
+  Emptied:
+    m_PersistentCalls:
+      m_Calls: []
+  currentIndex: 0
+  elements:
+  - {fileID: 7942253547472280052}
+  - {fileID: 7942253549173382210}
+  - {fileID: 7942253548521844098}
+  - {fileID: 7942253549292885116}
+  - {fileID: 7942253548155841926}
+  - {fileID: 7942253548912263673}
+  - {fileID: 7942253549258600848}
+  - {fileID: 7942253549076793251}
+  - {fileID: 7942253547704166940}
+--- !u!1 &7942253548066297809
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7942253548066297810}
+  m_Layer: 0
+  m_Name: VelocityTrackers
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7942253548066297810
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7942253548066297809}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 7942253549337417398}
+  - {fileID: 7942253548338181970}
+  - {fileID: 7942253548747452049}
+  m_Father: {fileID: 7942253549504944521}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &7942253548155841924
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7942253548155841925}
+  - component: {fileID: 7942253548155841926}
+  m_Layer: 0
+  m_Name: LongMedium
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7942253548155841925
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7942253548155841924}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 7942253548006442778}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &7942253548155841926
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7942253548155841924}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6fec9b03b1c34f846a9871a0e725ef7a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  intensity: 0.35
+  device: 2
+  duration: 0.5
+  useAdaptiveHand: 0
+--- !u!1 &7942253548236192318
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7942253548236192319}
+  - component: {fileID: 7942253548236192288}
+  m_Layer: 0
+  m_Name: ContinuousLight
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7942253548236192319
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7942253548236192318}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 7942253548697926261}
+  m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &7942253548236192288
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7942253548236192318}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6fec9b03b1c34f846a9871a0e725ef7a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  intensity: 0.15
+  device: 3
+  duration: Infinity
+  useAdaptiveHand: 0
+--- !u!1 &7942253548338181969
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7942253548338181970}
+  - component: {fileID: 7942253548338181971}
+  m_Layer: 0
+  m_Name: Left Controller
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7942253548338181970
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7942253548338181969}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 7942253548066297810}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &7942253548338181971
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7942253548338181969}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f27fc0668d79644c93af545a243c86a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  source: {fileID: 7942253548358264807}
+  relativeTo: {fileID: 7942253549504944517}
+  isEstimating: 1
+  velocityAverageFrames: 5
+  angularVelocityAverageFrames: 10
+--- !u!1 &7942253548358264807
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7942253548358264808}
+  - component: {fileID: 7942253548358264810}
+  - component: {fileID: 7942253548358264811}
+  - component: {fileID: 7942253548358264809}
+  m_Layer: 0
+  m_Name: Left Controller
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7942253548358264808
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7942253548358264807}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 691168427085168206}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &7942253548358264810
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7942253548358264807}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5a2a9c34df4095f47b9ca8f975175f5b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Device: 1
+  m_PoseSource: 4
+  m_PoseProviderComponent: {fileID: 0}
+  m_TrackingType: 0
+  m_UpdateType: 0
+  m_UseRelativeTransform: 0
+--- !u!114 &7942253548358264811
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7942253548358264807}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6ef6888ffd7db64479799fc534e1d0d1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  TrackingBegun:
+    m_PersistentCalls:
+      m_Calls: []
+  ConnectionStatusChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  TrackingTypeChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  BatteryChargeStatusChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  PassThroughCameraWasEnabled:
+    m_PersistentCalls:
+      m_Calls: []
+  PassThroughCameraWasDisabled:
+    m_PersistentCalls:
+      m_Calls: []
+  device: 3
+  passthroughProcessor: {fileID: 0}
+--- !u!114 &7942253548358264809
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7942253548358264807}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a11862926720f544fb5d904995c2b57b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  source:
+    field: {fileID: 7942253548358264811}
+  onlyProcessOnActiveAndEnabled: 1
+  interval: 0.25
+--- !u!1 &7942253548460966001
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7942253548460966002}
+  - component: {fileID: 7942253548460966003}
+  m_Layer: 0
+  m_Name: ShortMedium
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7942253548460966002
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7942253548460966001}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 7942253548697926261}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &7942253548460966003
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7942253548460966001}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6fec9b03b1c34f846a9871a0e725ef7a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  intensity: 0.35
+  device: 3
+  duration: 0.1
+  useAdaptiveHand: 0
+--- !u!1 &7942253548521844096
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7942253548521844097}
+  - component: {fileID: 7942253548521844098}
+  m_Layer: 0
+  m_Name: ShortStrong
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7942253548521844097
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7942253548521844096}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 7942253548006442778}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &7942253548521844098
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7942253548521844096}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6fec9b03b1c34f846a9871a0e725ef7a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  intensity: 1
+  device: 2
+  duration: 0.1
+  useAdaptiveHand: 0
+--- !u!1 &7942253548554999217
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7942253548554999218}
+  - component: {fileID: 7942253548554999219}
+  m_Layer: 0
+  m_Name: RightController
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7942253548554999218
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7942253548554999217}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 7942253548006442778}
+  m_Father: {fileID: 7942253548729916209}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &7942253548554999219
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7942253548554999217}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6fec9b03b1c34f846a9871a0e725ef7a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  intensity: 1
+  device: 2
+  duration: 0.1
+  useAdaptiveHand: 0
+--- !u!1 &7942253548697926260
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7942253548697926261}
+  - component: {fileID: 7942253548697926262}
+  m_Layer: 0
+  m_Name: LeftHapticProfiles
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7942253548697926261
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7942253548697926260}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 7942253547549808210}
+  - {fileID: 7942253548460966002}
+  - {fileID: 7942253549419812168}
+  - {fileID: 7942253547804923115}
+  - {fileID: 7942253547552027028}
+  - {fileID: 7942253549467390298}
+  - {fileID: 7942253548236192319}
+  - {fileID: 7942253549135372142}
+  - {fileID: 7942253547616981656}
+  m_Father: {fileID: 7942253548974779209}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &7942253548697926262
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7942253548697926260}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0dea9bd4fa4b5cc4b9b36a77382cb3b5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Obtained:
+    m_PersistentCalls:
+      m_Calls: []
+  Found:
+    m_PersistentCalls:
+      m_Calls: []
+  NotFound:
+    m_PersistentCalls:
+      m_Calls: []
+  IsEmpty:
+    m_PersistentCalls:
+      m_Calls: []
+  IsPopulated:
+    m_PersistentCalls:
+      m_Calls: []
+  Populated:
+    m_PersistentCalls:
+      m_Calls: []
+  Added:
+    m_PersistentCalls:
+      m_Calls: []
+  Removed:
+    m_PersistentCalls:
+      m_Calls: []
+  Emptied:
+    m_PersistentCalls:
+      m_Calls: []
+  currentIndex: 0
+  elements:
+  - {fileID: 7942253547549808211}
+  - {fileID: 7942253548460966003}
+  - {fileID: 7942253549419812169}
+  - {fileID: 7942253547804923116}
+  - {fileID: 7942253547552027029}
+  - {fileID: 7942253549467390299}
+  - {fileID: 7942253548236192288}
+  - {fileID: 7942253549135372143}
+  - {fileID: 7942253547616981657}
+--- !u!1 &7942253548729916208
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7942253548729916209}
+  m_Layer: 0
+  m_Name: HapticPulsers
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7942253548729916209
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7942253548729916208}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 7942253548974779209}
+  - {fileID: 7942253548554999218}
+  m_Father: {fileID: 7942253549504944521}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &7942253548747452015
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7942253548747452049}
+  - component: {fileID: 7942253548747452048}
+  m_Layer: 0
+  m_Name: Right Controller
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7942253548747452049
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7942253548747452015}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 7942253548066297810}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &7942253548747452048
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7942253548747452015}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f27fc0668d79644c93af545a243c86a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  source: {fileID: 7942253547876487858}
+  relativeTo: {fileID: 7942253549504944517}
+  isEstimating: 1
+  velocityAverageFrames: 5
+  angularVelocityAverageFrames: 10
+--- !u!1 &7942253548793007226
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7942253548793007227}
+  - component: {fileID: 7942253548793007228}
+  m_Layer: 0
+  m_Name: MomentProcessor
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7942253548793007227
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7942253548793007226}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 7942253549326039838}
+  m_Father: {fileID: 7942253549504944521}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &7942253548793007228
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7942253548793007226}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5c0eab237e25807459af1c5caf4d3d33, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  processMoment: 3
+  processes: {fileID: 7942253549326039839}
+--- !u!1 &7942253548912263671
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7942253548912263672}
+  - component: {fileID: 7942253548912263673}
+  m_Layer: 0
+  m_Name: LongStrong
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7942253548912263672
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7942253548912263671}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 7942253548006442778}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &7942253548912263673
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7942253548912263671}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6fec9b03b1c34f846a9871a0e725ef7a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  intensity: 1
+  device: 2
+  duration: 0.5
+  useAdaptiveHand: 0
+--- !u!1 &7942253548974779208
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7942253548974779209}
+  - component: {fileID: 7942253548974779210}
+  m_Layer: 0
+  m_Name: LeftController
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7942253548974779209
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7942253548974779208}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 7942253548697926261}
+  m_Father: {fileID: 7942253548729916209}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &7942253548974779210
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7942253548974779208}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6fec9b03b1c34f846a9871a0e725ef7a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  intensity: 1
+  device: 3
+  duration: 0.1
+  useAdaptiveHand: 0
+--- !u!1 &7942253549076793249
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7942253549076793250}
+  - component: {fileID: 7942253549076793251}
+  m_Layer: 0
+  m_Name: ContinuousMedium
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7942253549076793250
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7942253549076793249}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 7942253548006442778}
+  m_RootOrder: 7
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &7942253549076793251
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7942253549076793249}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6fec9b03b1c34f846a9871a0e725ef7a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  intensity: 0.35
+  device: 2
+  duration: Infinity
+  useAdaptiveHand: 0
+--- !u!1 &7942253549135372141
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7942253549135372142}
+  - component: {fileID: 7942253549135372143}
+  m_Layer: 0
+  m_Name: ContinuousMedium
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7942253549135372142
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7942253549135372141}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 7942253548697926261}
+  m_RootOrder: 7
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &7942253549135372143
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7942253549135372141}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6fec9b03b1c34f846a9871a0e725ef7a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  intensity: 0.35
+  device: 3
+  duration: Infinity
+  useAdaptiveHand: 0
+--- !u!1 &7942253549173382208
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7942253549173382209}
+  - component: {fileID: 7942253549173382210}
+  m_Layer: 0
+  m_Name: ShortMedium
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7942253549173382209
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7942253549173382208}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 7942253548006442778}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &7942253549173382210
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7942253549173382208}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6fec9b03b1c34f846a9871a0e725ef7a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  intensity: 0.35
+  device: 2
+  duration: 0.1
+  useAdaptiveHand: 0
+--- !u!1 &7942253549258600814
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7942253549258600815}
+  - component: {fileID: 7942253549258600848}
+  m_Layer: 0
+  m_Name: ContinuousLight
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7942253549258600815
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7942253549258600814}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 7942253548006442778}
+  m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &7942253549258600848
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7942253549258600814}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6fec9b03b1c34f846a9871a0e725ef7a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  intensity: 0.15
+  device: 2
+  duration: Infinity
+  useAdaptiveHand: 0
+--- !u!1 &7942253549292885114
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7942253549292885115}
+  - component: {fileID: 7942253549292885116}
+  m_Layer: 0
+  m_Name: LongLight
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7942253549292885115
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7942253549292885114}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 7942253548006442778}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &7942253549292885116
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7942253549292885114}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6fec9b03b1c34f846a9871a0e725ef7a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  intensity: 0.15
+  device: 2
+  duration: 0.5
+  useAdaptiveHand: 0
+--- !u!1 &7942253549326039837
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7942253549326039838}
+  - component: {fileID: 7942253549326039839}
+  m_Layer: 0
+  m_Name: ListContainer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7942253549326039838
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7942253549326039837}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 7942253548793007227}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &7942253549326039839
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7942253549326039837}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 15a9c53f0e146454cb669c38817bd5b7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Obtained:
+    m_PersistentCalls:
+      m_Calls: []
+  Found:
+    m_PersistentCalls:
+      m_Calls: []
+  NotFound:
+    m_PersistentCalls:
+      m_Calls: []
+  IsEmpty:
+    m_PersistentCalls:
+      m_Calls: []
+  IsPopulated:
+    m_PersistentCalls:
+      m_Calls: []
+  Populated:
+    m_PersistentCalls:
+      m_Calls: []
+  Added:
+    m_PersistentCalls:
+      m_Calls: []
+  Removed:
+    m_PersistentCalls:
+      m_Calls: []
+  Emptied:
+    m_PersistentCalls:
+      m_Calls: []
+  currentIndex: 0
+  elements:
+  - {fileID: 0}
+  - {fileID: 7942253549337373220}
+  - {fileID: 7942253548358264809}
+  - {fileID: 7942253547876487860}
+--- !u!114 &7942253549337373221
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 691168426911886060}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6ef6888ffd7db64479799fc534e1d0d1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  TrackingBegun:
+    m_PersistentCalls:
+      m_Calls: []
+  ConnectionStatusChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  TrackingTypeChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  BatteryChargeStatusChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  PassThroughCameraWasEnabled:
+    m_PersistentCalls:
+      m_Calls: []
+  PassThroughCameraWasDisabled:
+    m_PersistentCalls:
+      m_Calls: []
+  device: 1
+  passthroughProcessor: {fileID: 0}
+--- !u!114 &7942253549337373220
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 691168426911886060}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a11862926720f544fb5d904995c2b57b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  source:
+    field: {fileID: 7942253549337373221}
+  onlyProcessOnActiveAndEnabled: 1
+  interval: 0.25
+--- !u!1 &7942253549337417397
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7942253549337417398}
+  - component: {fileID: 7942253549337417399}
+  m_Layer: 0
+  m_Name: Head
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7942253549337417398
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7942253549337417397}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 7942253548066297810}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &7942253549337417399
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7942253549337417397}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f27fc0668d79644c93af545a243c86a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  source: {fileID: 691168426911886060}
+  relativeTo: {fileID: 7942253549504944517}
+  isEstimating: 1
+  velocityAverageFrames: 5
+  angularVelocityAverageFrames: 10
+--- !u!1 &7942253549419812167
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7942253549419812168}
+  - component: {fileID: 7942253549419812169}
+  m_Layer: 0
+  m_Name: ShortStrong
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7942253549419812168
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7942253549419812167}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 7942253548697926261}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &7942253549419812169
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7942253549419812167}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6fec9b03b1c34f846a9871a0e725ef7a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  intensity: 1
+  device: 3
+  duration: 0.1
+  useAdaptiveHand: 0
+--- !u!1 &7942253549467390297
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7942253549467390298}
+  - component: {fileID: 7942253549467390299}
+  m_Layer: 0
+  m_Name: LongStrong
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7942253549467390298
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7942253549467390297}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 7942253548697926261}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &7942253549467390299
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7942253549467390297}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6fec9b03b1c34f846a9871a0e725ef7a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  intensity: 1
+  device: 3
+  duration: 0.5
+  useAdaptiveHand: 0
+--- !u!1 &7942253549504944517
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7942253549504944521}
+  - component: {fileID: 7942253549504944520}
+  - component: {fileID: 7942253549504944519}
+  - component: {fileID: 7942253549504944518}
+  m_Layer: 0
+  m_Name: CameraRigs.WaveXR
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7942253549504944521
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7942253549504944517}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 691168426765690542}
+  - {fileID: 7942253548729916209}
+  - {fileID: 7942253548066297810}
+  - {fileID: 7942253548793007227}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &7942253549504944520
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7942253549504944517}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 34c0cb8bdc24787439e43b7f145ac31c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  playArea: {fileID: 7942253549504944517}
+  headset: {fileID: 691168426911886060}
+  headsetCamera: {fileID: 691168426911886062}
+  headsetVelocityTracker: {fileID: 7942253549337417399}
+  supplementHeadsetCameras: {fileID: 0}
+  headsetDeviceDetails: {fileID: 7942253549337373221}
+  dominantController: {fileID: 7942253549504944519}
+  leftController: {fileID: 7942253548358264807}
+  leftControllerVelocityTracker: {fileID: 7942253548338181971}
+  leftControllerHapticProcess: {fileID: 7942253548974779210}
+  leftControllerHapticProfiles: {fileID: 7942253548697926262}
+  leftControllerDeviceDetails: {fileID: 7942253548358264811}
+  rightController: {fileID: 7942253547876487858}
+  rightControllerVelocityTracker: {fileID: 7942253548747452048}
+  rightControllerHapticProcess: {fileID: 7942253548554999219}
+  rightControllerHapticProfiles: {fileID: 7942253548006442777}
+  rightControllerDeviceDetails: {fileID: 7942253547876487859}
+--- !u!114 &7942253549504944519
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7942253549504944517}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7512583a373897b4aa8971c27e3264cd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  leftController: {fileID: 7942253548358264811}
+  rightController: {fileID: 7942253547876487859}
+  IsChanging:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &7942253549504944518
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7942253549504944517}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a11862926720f544fb5d904995c2b57b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  source:
+    field: {fileID: 7942253549504944519}
+  onlyProcessOnActiveAndEnabled: 1
+  interval: 0.25
+--- !u!1001 &7942253549337373247
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 7942253549504944521}
+    m_Modifications:
+    - target: {fileID: 7471202952708050064, guid: be3d9716d14868d42a47f740f224b521,
+        type: 3}
+      propertyPath: m_Name
+      value: Wave Rig
+      objectReference: {fileID: 0}
+    - target: {fileID: 7471202952708050065, guid: be3d9716d14868d42a47f740f224b521,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7471202952708050065, guid: be3d9716d14868d42a47f740f224b521,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7471202952708050065, guid: be3d9716d14868d42a47f740f224b521,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7471202952708050065, guid: be3d9716d14868d42a47f740f224b521,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7471202952708050065, guid: be3d9716d14868d42a47f740f224b521,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7471202952708050065, guid: be3d9716d14868d42a47f740f224b521,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7471202952708050065, guid: be3d9716d14868d42a47f740f224b521,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7471202952708050065, guid: be3d9716d14868d42a47f740f224b521,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7471202952708050065, guid: be3d9716d14868d42a47f740f224b521,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7471202952708050065, guid: be3d9716d14868d42a47f740f224b521,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7471202952708050065, guid: be3d9716d14868d42a47f740f224b521,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: be3d9716d14868d42a47f740f224b521, type: 3}
+--- !u!20 &691168426911886062 stripped
+Camera:
+  m_CorrespondingSourceObject: {fileID: 7471202952327889105, guid: be3d9716d14868d42a47f740f224b521,
+    type: 3}
+  m_PrefabInstance: {fileID: 7942253549337373247}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &691168426911886060 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7471202952327889107, guid: be3d9716d14868d42a47f740f224b521,
+    type: 3}
+  m_PrefabInstance: {fileID: 7942253549337373247}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &691168427085168206 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7471202952090653809, guid: be3d9716d14868d42a47f740f224b521,
+    type: 3}
+  m_PrefabInstance: {fileID: 7942253549337373247}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &691168426765690542 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7471202952708050065, guid: be3d9716d14868d42a47f740f224b521,
+    type: 3}
+  m_PrefabInstance: {fileID: 7942253549337373247}
+  m_PrefabAsset: {fileID: 0}

--- a/Runtime/Prefabs/CameraRigs.WaveXR.prefab.meta
+++ b/Runtime/Prefabs/CameraRigs.WaveXR.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 8502542f76c58504dbaea28fd4958c06
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/SharedResources.meta
+++ b/Runtime/SharedResources.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: bef62e2fbdf57b84d8481bccf82bf205
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/SharedResources/Scripts.meta
+++ b/Runtime/SharedResources/Scripts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3e45c459986d8954481f0b0aed09d577
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/SharedResources/Scripts/Haptics.meta
+++ b/Runtime/SharedResources/Scripts/Haptics.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 04bae752fd2c082439db538c60d08e26
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/SharedResources/Scripts/Haptics/WXRDeviceHapticPulser.cs
+++ b/Runtime/SharedResources/Scripts/Haptics/WXRDeviceHapticPulser.cs
@@ -1,0 +1,74 @@
+﻿namespace Tilia.SDK.WaveXR.Haptics
+{
+    using UnityEngine;
+    using Wave.Essence;
+    using Zinnia.Haptics;
+
+    /// <summary>
+    /// Creates a single haptic pulse on a <see cref="XR_Device"/> supported haptic device.
+    /// </summary>
+    public class WXRDeviceHapticPulser : HapticPulser
+    {
+        [Tooltip("The device to pulse.")]
+        [SerializeField]
+        private XR_Device device;
+        /// <summary>
+        /// The device to pulse.
+        /// </summary>
+        public XR_Device Device
+        {
+            get
+            {
+                return device;
+            }
+            set
+            {
+                device = value;
+            }
+        }
+        [Tooltip("The duration to pulse the XR_Device for in seconds.")]
+        [SerializeField]
+        private float duration = 0.1f;
+        /// <summary>
+        /// The duration to pulse the <see cref="XR_Device"/> for in seconds.
+        /// </summary>
+        public float Duration
+        {
+            get
+            {
+                return duration;
+            }
+            set
+            {
+                duration = value;
+            }
+        }
+        [Tooltip("Determines whether to pulse the adpated dominant controller or just the given Device.")]
+        [SerializeField]
+        private bool useAdaptiveHand = false;
+        /// <summary>
+        /// Determines whether to pulse the adpated dominant controller or just the given <see cref="Device"/>.
+        /// </summary>
+        public bool UseAdaptiveHand
+        {
+            get
+            {
+                return useAdaptiveHand;
+            }
+            set
+            {
+                useAdaptiveHand = value;
+            }
+        }
+
+        protected override void DoBegin()
+        {
+            WXRDevice.SendHapticImpulse(device, Intensity, Duration, UseAdaptiveHand);
+        }
+
+        protected override void DoCancel()
+        {
+            WXRDevice.SendHapticImpulse(device, 0f, 0f, UseAdaptiveHand);
+        }
+    }
+}

--- a/Runtime/SharedResources/Scripts/Haptics/WXRDeviceHapticPulser.cs.meta
+++ b/Runtime/SharedResources/Scripts/Haptics/WXRDeviceHapticPulser.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6fec9b03b1c34f846a9871a0e725ef7a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/SharedResources/Scripts/Tracking.meta
+++ b/Runtime/SharedResources/Scripts/Tracking.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 046185c75847fdc41b162c6911b056a6
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/SharedResources/Scripts/Tracking/CameraRig.meta
+++ b/Runtime/SharedResources/Scripts/Tracking/CameraRig.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4f2ac7fa60f812243915b9365a30714d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/SharedResources/Scripts/Tracking/CameraRig/WVRDeviceDetailsRecord.cs
+++ b/Runtime/SharedResources/Scripts/Tracking/CameraRig/WVRDeviceDetailsRecord.cs
@@ -1,0 +1,175 @@
+﻿namespace Tilia.SDK.WaveXR.Tracking.CameraRig
+{
+    using Tilia.SDK.WaveXR.Visual;
+    using UnityEngine;
+    using UnityEngine.XR;
+    using Wave.Native;
+    using Zinnia.Tracking.CameraRig;
+    using ZinniaExtensions = Zinnia.Extension;
+
+    /// <summary>
+    /// A <see cref="DeviceDetailsRecord"/> for a <see cref="WVR_DeviceType"/>.
+    /// </summary>
+    public class WVRDeviceDetailsRecord : BaseDeviceDetailsRecord
+    {
+        [Tooltip("The device to listen for the state change on.")]
+        [SerializeField]
+        private WVR_DeviceType device;
+        /// <summary>
+        /// The device to listen for the state change on.
+        /// </summary>
+        public WVR_DeviceType Device
+        {
+            get
+            {
+                return device;
+            }
+            set
+            {
+                device = value;
+            }
+        }
+        [Tooltip("The PassthroughLayerProcessor for handling the camera passthrough.")]
+        [SerializeField]
+        private PassthroughLayerProcessor passthroughProcessor;
+        /// <summary>
+        /// The <see cref="PassthroughLayerProcessor"/> for handling the camera passthrough.
+        /// </summary>
+        public PassthroughLayerProcessor PassthroughProcessor
+        {
+            get
+            {
+                return passthroughProcessor;
+            }
+            set
+            {
+                passthroughProcessor = value;
+            }
+        }
+
+        /// <inheritdoc/>
+        public override XRNode XRNodeType { get => GetXRNodeFromDevice(Device); protected set => throw new System.NotImplementedException(); }
+        /// <inheritdoc/>
+        public override bool IsConnected { get => Interop.WVR_IsDeviceConnected(Device); protected set => throw new System.NotImplementedException(); }
+        /// <inheritdoc/>
+        public override int Priority { get => Interop.WVR_GetFocusedController() == Device ? 0 : 1; protected set => throw new System.NotImplementedException(); }
+        /// <inheritdoc/>
+        public override SpatialTrackingType TrackingType { get => GetTrackingType(Device); protected set => throw new System.NotImplementedException(); }
+        /// <inheritdoc/>
+        public override float BatteryLevel { get => Interop.WVR_GetDeviceBatteryPercentage(Device); protected set => throw new System.NotImplementedException(); }
+        /// <inheritdoc/>
+        public override BatteryStatus BatteryChargeStatus { get => GetBatteryStatusFromChargeStatus(Device); protected set => throw new System.NotImplementedException(); }
+        /// <inheritdoc/>
+        public override bool HasPassThroughCamera { get => HasPassThroughFeature() && PassthroughProcessor != null; protected set => throw new System.NotImplementedException(); }
+
+        /// <inheritdoc/>
+        protected override void EnablePassThrough()
+        {
+            if (!HasPassThroughCamera)
+            {
+                return;
+            }
+
+            PassthroughProcessor.EnablePassthrough();
+            base.EnablePassThrough();
+        }
+
+        /// <inheritdoc/>
+        protected override void DisablePassThrough()
+        {
+            if (!HasPassThroughCamera)
+            {
+                return;
+            }
+
+            PassthroughProcessor.DisablePassthrough();
+            base.DisablePassThrough();
+        }
+
+        /// <summary>
+        /// Sets the <see cref="DeviceType"/>.
+        /// </summary>
+        /// <param name="index">The index of the <see cref="WVR_DeviceType"/>.</param>
+        public virtual void SetDeviceType(int index)
+        {
+            Device = ZinniaExtensions.EnumExtensions.GetByIndex<WVR_DeviceType>(index);
+        }
+
+        /// <summary>
+        /// Gets the corresponding <see cref="XRNode"/> from the given <see cref="WVR_DeviceType"/>.
+        /// </summary>
+        /// <param name="device">The device type to convert.</param>
+        /// <returns>The converted XR Node.</returns>
+        protected virtual XRNode GetXRNodeFromDevice(WVR_DeviceType device)
+        {
+            switch (device)
+            {
+                case WVR_DeviceType.WVR_DeviceType_HMD:
+                    return XRNode.Head;
+                case WVR_DeviceType.WVR_DeviceType_Controller_Left:
+                case WVR_DeviceType.WVR_DeviceType_ElectronicHand_Left:
+                case WVR_DeviceType.WVR_DeviceType_NaturalHand_Left:
+                    return XRNode.LeftHand;
+                case WVR_DeviceType.WVR_DeviceType_Controller_Right:
+                case WVR_DeviceType.WVR_DeviceType_ElectronicHand_Right:
+                case WVR_DeviceType.WVR_DeviceType_NaturalHand_Right:
+                    return XRNode.RightHand;
+                case WVR_DeviceType.WVR_DeviceType_Camera:
+                    return XRNode.CenterEye;
+                case WVR_DeviceType.WVR_DeviceType_Tracker:
+                    return XRNode.HardwareTracker;
+                default:
+                    return XRNode.TrackingReference;
+            }
+        }
+
+        /// <summary>
+        /// Gets the <see cref="SpatialTrackingType"/> of the given device.
+        /// </summary>
+        /// <param name="device">The device to check tracking on.</param>
+        /// <returns>Thge found tracking type.</returns>
+        protected virtual SpatialTrackingType GetTrackingType(WVR_DeviceType device)
+        {
+            switch (Interop.WVR_GetDegreeOfFreedom(device))
+            {
+                case WVR_NumDoF.WVR_NumDoF_3DoF:
+                    return SpatialTrackingType.RotationOnly;
+                case WVR_NumDoF.WVR_NumDoF_6DoF:
+                    return SpatialTrackingType.RotationAndPosition;
+            }
+
+            return SpatialTrackingType.Unknown;
+        }
+
+        /// <summary>
+        /// Gets the <see cref="BatteryStatus"/> from the given device.
+        /// </summary>
+        /// <param name="device">The device to get battery status for.</param>
+        /// <returns>The current device battery status.</returns>
+        protected virtual BatteryStatus GetBatteryStatusFromChargeStatus(WVR_DeviceType device)
+        {
+            switch (Interop.WVR_GetChargeStatus(device))
+            {
+                case WVR_ChargeStatus.WVR_ChargeStatus_Charging:
+                    return BatteryStatus.Charging;
+                case WVR_ChargeStatus.WVR_ChargeStatus_Discharging:
+                    return BatteryStatus.Discharging;
+                case WVR_ChargeStatus.WVR_ChargeStatus_Full:
+                    return BatteryStatus.Full;
+            }
+
+            return BatteryStatus.Unknown;
+        }
+
+        /// <summary>
+        /// Determines whether the device has a passthrough camera feature.
+        /// </summary>
+        /// <returns>Whether there is a passthrough camera feature.</returns>
+        protected virtual bool HasPassThroughFeature()
+        {
+            ulong supportedFeatures = WVR_Android.WVR_GetSupportedFeatures();
+            ulong passThruFeature = (ulong)WVR_SupportedFeature.WVR_SupportedFeature_PassthroughOverlay;
+            return (supportedFeatures & passThruFeature) == passThruFeature;
+        }
+    }
+}

--- a/Runtime/SharedResources/Scripts/Tracking/CameraRig/WVRDeviceDetailsRecord.cs.meta
+++ b/Runtime/SharedResources/Scripts/Tracking/CameraRig/WVRDeviceDetailsRecord.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6ef6888ffd7db64479799fc534e1d0d1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/SharedResources/Scripts/Visual.meta
+++ b/Runtime/SharedResources/Scripts/Visual.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c3a0ba5f24d1e9541b1ea5234dd38c70
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/SharedResources/Scripts/Visual/OverlayPassthroughLayerProcessor.cs
+++ b/Runtime/SharedResources/Scripts/Visual/OverlayPassthroughLayerProcessor.cs
@@ -1,0 +1,67 @@
+﻿namespace Tilia.SDK.WaveXR.Visual
+{
+    using UnityEngine;
+    using Wave.Native;
+    using Zinnia.Extension;
+
+    /// <summary>
+    /// Implements the WaveXR Overlay camera passthrough layer.
+    /// </summary>
+    public class OverlayPassthroughLayerProcessor : PassthroughLayerProcessor
+    {
+        [Tooltip("The alpha level of the overlay passthrough layer.")]
+        [SerializeField]
+        private float alphaValue = 0.5f;
+        /// <summary>
+        /// The alpha level of the overlay passthrough layer.
+        /// </summary>
+        public float AlphaValue
+        {
+            get
+            {
+                return alphaValue;
+            }
+            set
+            {
+                alphaValue = value;
+                if (this.IsMemberChangeAllowed())
+                {
+                    OnAfterAlphaValueChange();
+                }
+            }
+        }
+
+        /// <inheritdoc/>
+        public override void EnablePassthrough()
+        {
+            Interop.WVR_ShowPassthroughOverlay(true);
+        }
+
+        /// <inheritdoc/>
+        public override void DisablePassthrough()
+        {
+            Interop.WVR_ShowPassthroughOverlay(false);
+        }
+
+        /// <inheritdoc/>
+        public override void TogglePassthrough(bool enabled)
+        {
+            Interop.WVR_ShowPassthroughOverlay(enabled);
+        }
+
+        /// <inheritdoc/>
+        protected override void OnEnable()
+        {
+            base.OnEnable();
+            OnAfterAlphaValueChange();
+        }
+
+        /// <summary>
+        /// Called after <see cref="AlphaValue"/> has been changed.
+        /// </summary>
+        protected virtual void OnAfterAlphaValueChange()
+        {
+            Interop.WVR_SetPassthroughOverlayAlpha(AlphaValue);
+        }
+    }
+}

--- a/Runtime/SharedResources/Scripts/Visual/OverlayPassthroughLayerProcessor.cs.meta
+++ b/Runtime/SharedResources/Scripts/Visual/OverlayPassthroughLayerProcessor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1a86c8bdcd175eb4d89c02f4e4f7a7cd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/SharedResources/Scripts/Visual/PassthroughLayerProcessor.cs
+++ b/Runtime/SharedResources/Scripts/Visual/PassthroughLayerProcessor.cs
@@ -1,0 +1,61 @@
+﻿namespace Tilia.SDK.WaveXR.Visual
+{
+    using UnityEngine;
+    using Wave.Native;
+    using Zinnia.Extension;
+
+    /// <summary>
+    /// The basis for defining a WaveXR passthrough layer.
+    /// </summary>
+    public abstract class PassthroughLayerProcessor : MonoBehaviour
+    {
+        [Tooltip("The image quality of the passthrough layer.")]
+        [SerializeField]
+        private WVR_PassthroughImageQuality imageQuality = WVR_PassthroughImageQuality.DefaultMode;
+        /// <summary>
+        /// The image quality of the passthrough layer.
+        /// </summary>
+        public WVR_PassthroughImageQuality ImageQuality
+        {
+            get
+            {
+                return imageQuality;
+            }
+            set
+            {
+                imageQuality = value;
+                if (this.IsMemberChangeAllowed())
+                {
+                    OnAfterImageQualityChange();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Enables the camera passthrough.
+        /// </summary>
+        public abstract void EnablePassthrough();
+        /// <summary>
+        /// Disables the camera passthrough.
+        /// </summary>
+        public abstract void DisablePassthrough();
+        /// <summary>
+        /// Toggles the camera passthrough state.
+        /// </summary>
+        /// <param name="enabled">Whether to toggle to the enabled state or not.</param>
+        public abstract void TogglePassthrough(bool enabled);
+
+        protected virtual void OnEnable()
+        {
+            OnAfterImageQualityChange();
+        }
+
+        /// <summary>
+        /// Called after <see cref="ImageQuality"/> has been changed.
+        /// </summary>
+        protected virtual void OnAfterImageQualityChange()
+        {
+            Interop.WVR_SetPassthroughImageQuality(ImageQuality);
+        }
+    }
+}

--- a/Runtime/SharedResources/Scripts/Visual/PassthroughLayerProcessor.cs.meta
+++ b/Runtime/SharedResources/Scripts/Visual/PassthroughLayerProcessor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d397f7c5f5ce213409f1675dc26f159b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/SharedResources/Scripts/Visual/UnderlayPassthroughLayerProcessor.cs
+++ b/Runtime/SharedResources/Scripts/Visual/UnderlayPassthroughLayerProcessor.cs
@@ -1,0 +1,28 @@
+﻿namespace Tilia.SDK.WaveXR.Visual
+{
+    using Wave.Native;
+
+    /// <summary>
+    /// Implements the WaveXR Underlay camera passthrough layer.
+    /// </summary>
+    public class UnderlayPassthroughLayerProcessor : PassthroughLayerProcessor
+    {
+        /// <inheritdoc/>
+        public override void EnablePassthrough()
+        {
+            Interop.WVR_ShowPassthroughUnderlay(true);
+        }
+
+        /// <inheritdoc/>
+        public override void DisablePassthrough()
+        {
+            Interop.WVR_ShowPassthroughUnderlay(false);
+        }
+
+        /// <inheritdoc/>
+        public override void TogglePassthrough(bool enabled)
+        {
+            Interop.WVR_ShowPassthroughUnderlay(enabled);
+        }
+    }
+}

--- a/Runtime/SharedResources/Scripts/Visual/UnderlayPassthroughLayerProcessor.cs.meta
+++ b/Runtime/SharedResources/Scripts/Visual/UnderlayPassthroughLayerProcessor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a17dc6e3e0a5f2d468cc4b4bbf05d2c1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Tilia.SDK.WaveXR.Unity.Runtime.asmdef
+++ b/Runtime/Tilia.SDK.WaveXR.Unity.Runtime.asmdef
@@ -1,0 +1,18 @@
+{
+    "name": "Tilia.SDK.WaveXR.Unity.Runtime",
+    "references": [
+        "GUID:23756adb8cb36e64587322ad0ecdf5e3",
+        "GUID:b61e31fcaa3ec465fb7e4835ff61bfc2",
+        "GUID:b7c74153ccbcf534aa653a77f62bd182",
+        "GUID:dc6ae5be80485d949a25aa157e051ed8"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Runtime/Tilia.SDK.WaveXR.Unity.Runtime.asmdef.meta
+++ b/Runtime/Tilia.SDK.WaveXR.Unity.Runtime.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 59af1906ebfffe549bdd53f3bb834205
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/docfx.json
+++ b/docfx.json
@@ -1,0 +1,60 @@
+{
+  "metadata": [
+    {
+      "src": [
+        {
+          "files": [
+            "Runtime/**.cs"
+          ]
+        }
+      ],
+      "dest": "_TEMP_DOCS/API",
+      "disableGitFeatures": false,
+      "disableDefaultFilter": false
+    }
+  ],
+  "build": {
+    "content": [
+      {
+        "files": [
+          "_TEMP_DOCS/API/**.yml",
+          "_TEMP_DOCS/API/index.md"
+        ]
+      },
+      {
+        "files": [
+          "*.md"
+        ]
+      }
+    ],
+    "resource": [
+      {
+        "files": [
+        ]
+      }
+    ],
+    "overwrite": [
+      {
+        "files": [
+          "apidoc/**.md"
+        ],
+        "exclude": [
+          "obj/**",
+          "_site/**"
+        ]
+      }
+    ],
+    "dest": "_TEMP_DOCS/output",
+    "globalMetadataFiles": [],
+    "fileMetadataFiles": [],
+    "template": [
+      "default"
+    ],
+    "postProcessors": [],
+    "markdownEngineName": "markdig",
+    "noLangKeyword": false,
+    "keepFileLink": false,
+    "cleanupCacheHistory": false,
+    "disableGitFeatures": false
+  }
+}

--- a/docfx.json.meta
+++ b/docfx.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 61b09f640c64ad540b20538fff4cc988
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/package.json
+++ b/package.json
@@ -1,23 +1,24 @@
 {
-    "name": "io.extendreality.tilia.{scope}.{feature}.{platform?}",
-    "displayName": "Tilia {scope}.{feature}.{platform?}",
-    "description": "{Description of feature.}",
-    "changelogUrl": "https://github.com/ExtendRealityLtd/Tilia.{scope}.{feature}.{platform?}/blob/master/CHANGELOG.md",
-    "documentationUrl": "https://github.com/ExtendRealityLtd/Tilia.{scope}.{feature}.{platform?}/tree/master/Documentation",
-    "licensesUrl": "https://github.com/ExtendRealityLtd/Tilia.CameraRigs.{scope}.{feature}.{platform?}/blob/master/LICENSE.md",
+    "name": "io.extendreality.tilia.sdk.wavexr.unity",
+    "displayName": "Tilia SDK WaveXR Unity",
+    "description": "SDK Wrappers for the WaveXR Plugin Unity asset.",
+    "changelogUrl": "https://github.com/ExtendRealityLtd/Tilia.SDK.WaveXR.Unity/blob/master/CHANGELOG.md",
+    "documentationUrl": "https://github.com/ExtendRealityLtd/Tilia.SDK.WaveXR.Unity/tree/master/Documentation",
+    "licensesUrl": "https://github.com/ExtendRealityLtd/Tilia.SDK.WaveXR.Unity/blob/master/LICENSE.md",
     "version": "1.0.0",
-    "unity": "2018.3",
-    "unityRelease": "10f1",
+    "unity": "2019.4",
+    "unityRelease": "40f1",
     "keywords": [
-        "pattern"
+        "sdk",
+        "wrapper"
     ],
-    "homepage": "https://github.com/ExtendRealityLtd/Tilia.{scope}.{feature}.{platform?}/",
+    "homepage": "https://github.com/ExtendRealityLtd/Tilia.SDK.WaveXR.Unity/",
     "bugs": {
-        "url": "https://github.com/ExtendRealityLtd/Tilia.{scope}.{feature}.{platform?}/issues"
+        "url": "https://github.com/ExtendRealityLtd/Tilia.SDK.WaveXR.Unity/issues"
     },
     "repository": {
         "type": "git",
-        "url": "ssh://git@github.com/ExtendRealityLtd/Tilia.{scope}.{feature}.{platform?}.git"
+        "url": "ssh://git@github.com/ExtendRealityLtd/Tilia.SDK.WaveXR.Unity.git"
     },
     "license": "MIT",
     "author": {
@@ -26,7 +27,9 @@
         "url": "https://github.com/ExtendRealityLtd"
     },
     "dependencies": {
-        "io.extendreality.zinnia.unity": "X.Y.Z"
+        "com.htc.upm.wave.xrsdk": "5.2.0-r.8",
+        "com.htc.upm.wave.essence": "5.2.0-r.8",
+        "io.extendreality.zinnia.unity": "2.8.0"
     },
     "files": [
         "*.md",
@@ -34,6 +37,8 @@
         "*.asmdef",
         "*.xml",
         "Documentation",
-        "Runtime"
+        "Runtime",
+        "Editor",
+        "docfx.json"
     ]
 }

--- a/package.json.meta
+++ b/package.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 82f6cf1d4c6e66746bff248b9eb33c18
+PackageManifestImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
The WaveXR SDK wrapper provides a way of being able to use the WaveXR SDK for Unity directly with the TrackedAlias so the underlying WaveXR SDK can be leveraged whilst still keeping a level of generics to the project.